### PR TITLE
Fixed issue with assigning only lexicon category that word belongs to in lexicon input file.

### DIFF
--- a/acculturation/lexicon.py
+++ b/acculturation/lexicon.py
@@ -75,7 +75,7 @@ class CSVLexicon:
             if self.word_key not in row:
                 print("Error: lexicon must include a '%s' field." % self.word_key)
             w = row[self.word_key]
-            cats = [c for c in row if c != self.word_key]
+            cats = [c for c in row if c != self.word_key and row[c]]
             if "*" in w:
                 # This entry should match all stems
                 stem = stemmer.stem_word(w)


### PR DESCRIPTION
There is an issue that any word mentioned in lexicon file had all categories assigned even if only one category was specified in file.
Let's see example:
```
Word,Positive,Negative
pretty,1,
```
as we may see 'pretty' belongs only to 'Positive' category.
But in code it's being assigned both:
```
Lexicon word:  OrderedDict([('Word', 'pretty'), ('Positive', '1'), ('Negative', '')])  >>> Categories assigned:   ['Positive', 'Negative']
```
after fix it looks like:
```
Lexicon word:  OrderedDict([('Word', 'pretty'), ('Positive', '1'), ('Negative', '')])  >>> Categories assigned:   ['Positive']
```